### PR TITLE
Improve Kerberoast Module

### DIFF
--- a/nxc/protocols/ldap.py
+++ b/nxc/protocols/ldap.py
@@ -900,7 +900,7 @@ class ldap(connection):
 
     def kerberoasting(self):
         # Building the search filter
-        searchFilter = "(&(servicePrincipalName=*)(UserAccountControl:1.2.840.113556.1.4.803:=512)(!(UserAccountControl:1.2.840.113556.1.4.803:=2))(!(objectCategory=computer)))"
+        searchFilter = "(&(servicePrincipalName=*)(!(objectCategory=computer)))"
         attributes = [
             "servicePrincipalName",
             "sAMAccountName",
@@ -951,7 +951,7 @@ class ldap(connection):
 
                     if mustCommit is True:
                         if int(userAccountControl) & UF_ACCOUNTDISABLE:
-                            self.logger.debug(f"Bypassing disabled account {sAMAccountName} ")
+                            self.logger.highlight(f"Bypassing disabled account {sAMAccountName} ")
                         else:
                             answers += [[spn, sAMAccountName, memberOf, pwdLastSet, lastLogon, delegation] for spn in SPNs]
                 except Exception as e:


### PR DESCRIPTION
On a test where --kerberoast would not return a ticket for a user I knew was kerberoastable. 

![image](https://github.com/Kahvi-0/NetExec/assets/46513413/91afdc8e-f2ed-4608-8fad-527cab3b52f5)

After some digging I changed the LDAP query in ldap.py to be just "(&(servicePrincipalName=*)(!(objectCategory=computer)))". This removes the check for accounts locked out/inactive and returned the ticket I was expecting. 

![image](https://github.com/Kahvi-0/NetExec/assets/46513413/c246b64f-4766-4244-9607-617201fbff35)


Personally would still like to get tickets for users that are disabled/locked out in order to attempt to crack their password and see if the password is reused. 

I also changed the error for "Bypassing disabled account {sAMAccountName}" to be highlight as I thought this is nice to have.